### PR TITLE
Untitled

### DIFF
--- a/DRX.Framework/Logger.cs
+++ b/DRX.Framework/Logger.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
+using DRX.Framework.Common.Utility;
 
 namespace DRX.Framework;
 
@@ -131,7 +132,7 @@ public static class Logger
                     Console.OutputEncoding = Encoding.UTF8;
                     var originalColor = Console.ForegroundColor;
                     Console.ForegroundColor = GetLogLevelColor(level);
-                    Console.Write(logText);
+                    Console.Write(ParseColorTags(logText));
                     Console.ForegroundColor = originalColor;
                     Console.WriteLine();
                     return;
@@ -142,17 +143,17 @@ public static class Logger
                 {
                     if (_boundTextBox != null)
                     {
-                        _boundTextBox.AppendText(logText + Environment.NewLine);
+                        _boundTextBox.AppendText(ParseColorTags(logText) + Environment.NewLine);
                         _boundTextBox.ScrollToEnd();
                     }
                     else if (_boundTextBlock != null)
                     {
-                        _boundTextBlock.Text += logText + Environment.NewLine;
+                        _boundTextBlock.Text += ParseColorTags(logText) + Environment.NewLine;
                     }
                     else if (_boundRichTextBox != null)
                     {
                         var paragraph = new Paragraph();
-                        var run = new Run(logText)
+                        var run = new Run(ParseColorTags(logText))
                         {
                             Foreground = GetWpfLogLevelBrush(level)
                         };
@@ -167,6 +168,37 @@ public static class Logger
                 Console.WriteLine($"[{DateTime.Now:yyyy/MM/dd HH:mm:ss}] [ERROR] 日志系统异常");
             }
         }
+    }
+
+    private static string ParseColorTags(string input)
+    {
+        var regexParam = new RegexParam
+        {
+            Input = input,
+            Mode = RegexMode.MatchContentBetweenStrings,
+            Param1 = "%color(",
+            Param2 = ")",
+            ReturnMode = ReturnMode.ReturnMatchedStrings,
+            Filter = ReturnFilter.All
+        };
+
+        var matches = DRXRegex.Execute(regexParam) as string[];
+        if (matches == null) return input;
+
+        foreach (var match in matches)
+        {
+            var colorValues = match.Replace("%color(", "").Replace(")", "").Split(',');
+            if (colorValues.Length == 3 &&
+                byte.TryParse(colorValues[0], out var r) &&
+                byte.TryParse(colorValues[1], out var g) &&
+                byte.TryParse(colorValues[2], out var b))
+            {
+                var color = Color.FromRgb(r, g, b);
+                input = input.Replace(match, $"[{color}]");
+            }
+        }
+
+        return input;
     }
 
     private static ConsoleColor GetLogLevelColor(LogLevel level) => level switch


### PR DESCRIPTION
Add a color identifier system to the logger.

* Add `ParseColorTags` method to parse color tags in log text.
* Modify `Log` method to use `ParseColorTags` for console output.
* Modify `Log` method to use `ParseColorTags` for WPF controls output.

